### PR TITLE
Forcing MeCab version to 0.996.6rc2

### DIFF
--- a/1_Japanese_BERT_on_Google_Colaboratory.ipynb
+++ b/1_Japanese_BERT_on_Google_Colaboratory.ipynb
@@ -1,17 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "1_Japanese_BERT_on_Google_Colaboratory.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -98,7 +85,7 @@
         }
       },
       "source": [
-        "!pip install mecab-python3"
+        "!pip install mecab-python3==0.996.6rc2"
       ],
       "execution_count": 2,
       "outputs": [
@@ -1362,5 +1349,18 @@
       "execution_count": 0,
       "outputs": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "name": "1_Japanese_BERT_on_Google_Colaboratory.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/1_Japanese_BERT_on_Google_Colaboratory.ipynb
+++ b/1_Japanese_BERT_on_Google_Colaboratory.ipynb
@@ -31,45 +31,19 @@
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 474
-        }
+        },
+        "tags": []
       },
       "source": [
         "!apt install aptitude swig\n",
         "!aptitude install mecab libmecab-dev mecab-ipadic-utf8 git make curl xz-utils file -y\n"
       ],
-      "execution_count": 1,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
-          "text": [
-            "Reading package lists... Done\n",
-            "Building dependency tree       \n",
-            "Reading state information... Done\n",
-            "aptitude is already the newest version (0.8.10-6ubuntu1).\n",
-            "swig is already the newest version (3.0.12-1).\n",
-            "0 upgraded, 0 newly installed, 0 to remove and 29 not upgraded.\n",
-            "mecab is already installed at the requested version (0.996-5)\n",
-            "libmecab-dev is already installed at the requested version (0.996-5)\n",
-            "mecab-ipadic-utf8 is already installed at the requested version (2.7.0-20070801+main-1)\n",
-            "git is already installed at the requested version (1:2.17.1-1ubuntu0.7)\n",
-            "make is already installed at the requested version (4.1-9.1ubuntu1)\n",
-            "curl is already installed at the requested version (7.58.0-2ubuntu3.8)\n",
-            "xz-utils is already installed at the requested version (5.2.2-1.3)\n",
-            "file is already installed at the requested version (1:5.32-2ubuntu0.3)\n",
-            "mecab is already installed at the requested version (0.996-5)\n",
-            "libmecab-dev is already installed at the requested version (0.996-5)\n",
-            "mecab-ipadic-utf8 is already installed at the requested version (2.7.0-20070801+main-1)\n",
-            "git is already installed at the requested version (1:2.17.1-1ubuntu0.7)\n",
-            "make is already installed at the requested version (4.1-9.1ubuntu1)\n",
-            "curl is already installed at the requested version (7.58.0-2ubuntu3.8)\n",
-            "xz-utils is already installed at the requested version (5.2.2-1.3)\n",
-            "file is already installed at the requested version (1:5.32-2ubuntu0.3)\n",
-            "No packages will be installed, upgraded, or removed.\n",
-            "0 packages upgraded, 0 newly installed, 0 to remove and 29 not upgraded.\n",
-            "Need to get 0 B of archives. After unpacking 0 B will be used.\n",
-            "                            \n"
-          ],
-          "name": "stdout"
+          "name": "stdout",
+          "text": "No Java runtime present, requesting install.\nzsh:1: command not found: aptitude\n"
         }
       ]
     },
@@ -701,7 +675,7 @@
         }
       },
       "source": [
-        "!pip install transformers==2.9.0"
+        "!pip install transformers==3.0.2"
       ],
       "execution_count": 10,
       "outputs": [
@@ -754,7 +728,7 @@
       },
       "source": [
         "# 分かち書きをするtokenizerです\n",
-        "tokenizer = BertJapaneseTokenizer.from_pretrained('bert-base-japanese-whole-word-masking')\n"
+        "tokenizer = BertJapaneseTokenizer.from_pretrained('cl-tohoku/bert-base-japanese-whole-word-masking')\n"
       ],
       "execution_count": 0,
       "outputs": []
@@ -772,7 +746,7 @@
       },
       "source": [
         "# BERTの日本語学習済みパラメータのモデルです\n",
-        "model = BertModel.from_pretrained('bert-base-japanese-whole-word-masking')\n",
+        "model = BertModel.from_pretrained('cl-tohoku/bert-base-japanese-whole-word-masking')\n",
         "print(model)"
       ],
       "execution_count": 13,
@@ -1093,7 +1067,7 @@
         "from transformers import BertConfig\n",
         "\n",
         "# 東北大学_日本語版の設定を確認\n",
-        "config_japanese = BertConfig.from_pretrained('bert-base-japanese-whole-word-masking')\n",
+        "config_japanese = BertConfig.from_pretrained('cl-tohoku/bert-base-japanese-whole-word-masking')\n",
         "print(config_japanese)"
       ],
       "execution_count": 14,


### PR DESCRIPTION
Forced MeCab version to 0.996.6rc2 to avoid breaking change on "-Ochasen" with MeCab version 1.0 and above.